### PR TITLE
Include more files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt
+graft tests


### PR DESCRIPTION
Include additional files in sdists.  In particular include the license text, which the license requires.  Also include tests.